### PR TITLE
Add parser for json-ld from html, along with json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openschemas/schemaorg/tree/master)
+ - added parser for json-ld embedded in html (0.0.15)
  - adding visual catalog template (0.0.14)
  - required/recommended should not be required for a recipe! [issue](https://github.com/openschemas/schemaorg/issues/6) (0.0.13)
  - missing top level of type to close [this issue](https://github.com/openschemas/schemaorg/issues/4) (0.0.12)

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,6 +190,37 @@ print(dataset)
 
 For the pretty templates, see the examples folder below.
 
+### 8. Read HTML with json-ld
+
+If you've generated an embedded json-ld, how do you load it again?
+You can actually use the BaseParser of the recipe to do this.
+
+```python
+result = RecipeParser('SoftwareSourceCode.html')
+[schemaorg-recipe][SoftwareSourceCode.html]
+```
+```
+result.loaded
+{'@context': 'http://www.schema.org',
+ '@type': 'SoftwareSourceCode',
+ 'about': 'This is a Dockerfile provided by the Dinosaur Dataset collection.',
+ 'codeRepository': 'https://www.github.com/openschemas/dockerfiles',
+ 'creator': {'@type': 'Person',
+  'contactPoint': {'@type': 'ContactPoint'},
+  'name': '@vsoch'},
+ 'description': 'A Dockerfile build recipe',
+ 'name': 'deforce/alpine-wxpython:latest',
+ 'runtime': 'Docker',
+ 'sameAs': 'ImageDefinition',
+ 'schemas': {},
+ 'thumbnailUrl': 'https://vsoch.github.io/datasets/assets/img/avocado.png',
+ 'version': '3.4'}
+```
+
+If there is interest, we could easily add to the library to look at the type,
+and the version, and load the initial schema with it. Please open an issue if 
+this would be useful to you!
+
 ## Examples
 
  - [openbases/extractor-dockerfile](https://www.github.com/openbases/extractor-dockerfile) is an minimal example showing how to extract metadata for a Dockerfile, for each of a containerRecipe and SoftwareSourceCode.

--- a/schemaorg/main/parse/__init__.py
+++ b/schemaorg/main/parse/__init__.py
@@ -18,3 +18,4 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 '''
 
 from .recipe import RecipeParser
+

--- a/schemaorg/main/parse/base.py
+++ b/schemaorg/main/parse/base.py
@@ -24,7 +24,13 @@ import re
 import sys
 
 from schemaorg.logger import bot
-from schemaorg.utils import ( read_file, write_file )
+from schemaorg.utils import ( 
+    read_file,
+    read_frontmatter,
+    write_file,
+    read_yaml,
+    write_yaml 
+)
 
 
 class RecipeBase(object):
@@ -36,21 +42,31 @@ class RecipeBase(object):
 
     '''
 
-    def __init__(self, recipe=None):
-        self.load(recipe)
+    loaded = {}
+    filename = None
 
-    def load(self, recipe):
-        '''load a recipe file into the client, first performing checks, and
-           then parsing the file.
+    def __init__(self, recipe=None):
+
+        # Did the user provide a path to load?
+        if recipe is not None:
+            self.set_filename(recipe)
+
+        # Load the recipe if provided and exists
+        if self.filename is not None:
+            self.load()
+
+    def set_filename(self, file_path):
+        '''add the filename to be parsed to the class
 
            Parameters
            ==========
-           recipe: the original recipe file, parsed by subclass
- 
+           file_path: the original recipe file, parsed by subclass
         '''
-        self.filename = recipe           # the recipe file
-        self._run_checks()             # does the recipe file exist?
-        self.parse()
+        if self._validate_exists(file_path):
+            self.filename = file_path
+        else:
+            bot.warning("%s does not exist." % file_path)
+
 
     def __str__(self):
         ''' show the user the recipe object, along with the type. E.g.,       
@@ -67,31 +83,117 @@ class RecipeBase(object):
         return self.__str__()
 
 
-    def _run_checks(self):
-        '''basic sanity checks for the file name (and others if needed) before
-           attempting parsing.
+    def _validate_exists(self, filename=None):
+        '''first determine if the filename is defined, with preference
+           to a potentially new file set by the user at runtime. If not set,
+           use previously loaded file. In both cases, first check if the
+           file exists. Return False if not defined or doesn't exist
+
+           Parameters
+           ==========
+           filename: a yaml file path, if desired, to override previously set
         '''
-        if self.filename is not None:
+        if not filename:
+            filename = self.filename
 
-            # Does the recipe provided exist?
-            if not os.path.exists(self.filename):
-                bot.error("Cannot find %s, is the path correct?" %self.filename)
-                sys.exit(1)
-
-            # Ensure we carry fullpath
-            self.filename = os.path.abspath(self.filename)
+        if filename in ['', None]:
+            bot.warning("Yaml file is not defined.")
+        elif not os.path.exists(filename):
+            bot.warning("%s does not exist." % filename)
+        return os.path.exists(filename or '')
 
 
-# Parse
+# Load
 
-    def parse(self):
-        '''parse is the base function for parsing the recipe. Right now, this
-           function basically calls the subclass _parse function if the recipe
-           has been defined.
+
+    def load(self, file_path=None):
+        '''load the yaml file depending on its extension. We can handle
+           html with json-ld, json-ld (or just json), markdown, and yaml.
+
+           Parameters
+           ==========
+           file_path: a yaml/html file path, if desired, to override previous
         '''
 
-        if self.filename:
+        if not file_path:
+            file_path = self.filename
 
-            # If properly instantiated by Docker or Singularity Recipe, parse
-            if hasattr(self, '_parse'):
-                self._parse()
+        # Read in raw content
+        if self._validate_exists(file_path):
+
+            # Read in yaml as json-ld from html
+            if file_path.endswith('html'):
+                self._load_html(file_path)
+
+            # Read in yaml as frontend matter
+            elif re.search('(md|markdown)$', file_path):
+                self.loaded = read_frontmatter(file_path)
+        
+            elif file_path.endswith('json'):
+                self.loaded = read_json(file_path)
+
+            # Read in standard yaml
+            else:
+                self.loaded = read_yaml(file_path)
+
+            # If the subclass has a load function, call now
+            if hasattr(self, '_load'):
+                self._load()
+
+            # Unpack or statements
+            return self.loaded
+             
+
+
+# Loading Helpers
+
+
+    def _load_html(self, file_path, encoding='utf-8'):
+        '''load as json-ld from html
+
+           Parameters
+           ==========
+           file_path: an html file path to read
+        '''
+        import lxml.html
+        import lxml
+        jsonld = lxml.etree.XPath('descendant-or-self::script[@type="application/ld+json"]')
+
+        try:
+            parser = lxml.html.HTMLParser(encoding=encoding)
+            content = read_file(file_path, readlines=False)
+            tree = lxml.html.fromstring(content, parser=parser)
+            self.loaded = json.loads(jsonld(tree)[0].text)
+        except:
+            bot.error('Error loading %s, is there json-ld in a script tag?' % file_path)
+
+
+# Saving
+
+    def save_yml(self, output_file, content=None, mode = 'w', ext='yml'):
+        '''save a yml file, either provided by the client (content)
+           or if not provided, the loaded content.
+         
+           Parameters
+           ==========
+           output_file: the output file to save to. Should end in yml or yaml
+           content: the content to parse to yaml, can be str or dict
+           mode: the mode to use (default is w, write)
+
+        '''
+        # If content isn't provided, use client loaded content (must be dict)
+        if not content:
+            content = self.loaded
+        
+        # Remove any derivation (won'account for compressed e.g., .tar.gz)
+        output_file, _ = os.path.splitext(output_file)
+
+        # Ensure ends with a yml derivative extension
+        if not re.search('(%s$)' % ext, output_file):
+            output_file = "%s.%s" % (output_file, ext)
+
+        # Write the yaml to file
+        write_yaml(content, output_file, mode) 
+
+    def save_yaml(self, output_file, content=None, mode = 'w'):
+        return self.save_yml(output_file, content, mode, ext='yaml')

--- a/schemaorg/main/parse/recipe.py
+++ b/schemaorg/main/parse/recipe.py
@@ -26,6 +26,7 @@ import sys
 from schemaorg.logger import bot
 from schemaorg.utils import ( 
     read_file,
+    read_frontmatter,
     write_file,
     read_yaml,
     write_yaml 
@@ -33,9 +34,8 @@ from schemaorg.utils import (
 from schemaorg.main.parse.base import RecipeBase
 from schemaorg.main.parse.validate import validate
 
-class RecipeParser(RecipeBase):
 
-    filename = None
+class RecipeParser(RecipeBase):
 
     def __init__(self, recipe=None):
         '''a recipe parses an input recipe file, a yaml file, into the expected 
@@ -46,145 +46,28 @@ class RecipeParser(RecipeBase):
            recipe: the recipe file (yaml)
 
         '''
-
-        self.loaded = {}
-
-        # Did the user provide a path to load?
-        if recipe is not None:
-            self.set_filename(recipe)
+        # The base will load the recipe, and then return to _load
         super(RecipeParser, self).__init__(recipe)
-
-
-    def set_filename(self, file_path):
-        if self._validate_exists(file_path):
-            self.filename = file_path
-        else:
-            bot.warning("%s does not exist." % file_path)
-
  
-    def _parse(self):
-        '''parse is the base function for parsing the recipe, and extracting
-           elements into the correct data structures. Everything is parsed into
-           lists or dictionaries that can be assembled again on demand.     
-        '''
-        self.load()
 
-    def _validate_exists(self, filename = None):
-        '''first determine if the filename is defined, with preference
-           to a potentially new file set by the user at runtime. If not set,
-           use previously loaded file. In both cases, first check if the
-           file exists. Return False if not defined or doesn't exist
-
-           Parameters
-           ==========
-           filename: a yaml file path, if desired, to override previously set
-        '''
-        if not filename:
-            filename = self.filename
-
-        if filename not in ['', None]:
-            if os.path.exists(filename):
-                return True
-            else:
-                bot.warning("%s does not exist." % filename)
-        else:
-            bot.warning("Yaml file is not defined.")
-        return False
-
-    def load(self, file_path=None):
-        '''load the yaml file depending on its extension
-
-           Parameters
-           ==========
-           file_path: a yaml/html file path, if desired, to override previous
-        '''
-
-        if not file_path:
-            file_path = self.filename
-
-        # Read in raw content
-        if self._validate_exists(file_path):
-
-            # Read in yaml as frontend matter from html
-            if file_path.endswith('html'):
-                self._load_html(file_path)
-
-            # Read in standard yaml
-            else:
-                self._load_yaml(file_path)
-
-
-            # Unpack or statements
-            self._finish_load()
-            return self.loaded
-
-# Loading
-
-    def _load_yaml(self, file_path):
-        '''load the yaml file
-
-           Parameters
-           ==========
-           file_path: the yaml file path to read
-        '''
-        self.loaded = read_yaml(file_path)
-
-        
-    def _load_html(self, file_path):
-        '''load the yaml as frontend matter from an html file
-
-           Parameters
-           ==========
-           file_path: an html file path to read
-        '''
-        stream = read_file(file_path, readlines=False)
-        self.loaded = frontmatter.loads(stream).metadata
-
-
-    def _finish_load(self):
+    def _load(self):
         '''The user is allowed to package "or" statements in the Yaml, meaning
            that a redundant entry for an equally defined Person and Organization
            could be written as "Person|Organization." To unwrap this, we put
            each into its own duplicated field.
         '''
         finished = dict()
-        for name, value in self.loaded['schemas'].items():
-            finished[name] = value
-            if "|" in name:
-                for part in name.split('|'):
-                    finished[part] = value
+
+        # If we aren't loading schemas, won't have this attribute.
+
+        if 'schemas' in self.loaded:
+            for name, value in self.loaded['schemas'].items():
+                finished[name] = value
+                if "|" in name:
+                    for part in name.split('|'):
+                        finished[part] = value
                     
         self.loaded['schemas'] = finished
-
-# Saving
-
-    def save_yml(self, output_file, content=None, mode = 'w', ext='yml'):
-        '''save a yml file, either provided by the client (content)
-           or if not provided, the loaded content.
-         
-           Parameters
-           ==========
-           output_file: the output file to save to. Should end in yml or yaml
-           content: the content to parse to yaml, can be str or dict
-           mode: the mode to use (default is w, write)
-
-        '''
-        # If content isn't provided, use client loaded content (must be dict)
-        if not content:
-            content = self.loaded
-        
-        # Remove any derivation (won'account for compressed e.g., .tar.gz)
-        output_file, _ = os.path.splitext(output_file)
-
-        # Ensure ends with a yml derivative extension
-        if not re.search('(%s$)' % ext, output_file):
-            output_file = "%s.%s" % (output_file, ext)
-
-        # Write the yaml to file
-        write_yaml(content, output_file, mode) 
-
-    def save_yaml(self, output_file, content=None, mode = 'w'):
-        return self.save_yml(output_file, content, mode, ext='yaml')
 
 
 # Reading
@@ -200,6 +83,7 @@ class RecipeParser(RecipeBase):
         if not hasattr(self, 'loaded'):
             self.load(self.filename)
         return self.loaded[key]
+
 
 # Validation
 

--- a/schemaorg/utils.py
+++ b/schemaorg/utils.py
@@ -242,6 +242,28 @@ def _read_yaml(section, quiet=False):
                 metadata[k] = v
     return metadata
 
+
+# Markdown and frontmatter
+
+def read_frontmatter(filename, mode='r', quiet=False):
+    '''read a yaml file, only including sections between dashes
+    '''
+    stream = read_file(filename, mode, readlines=False)
+
+    # The yml section always comes after the --- of the frontmatter
+    section = stream.split('---')[1]
+    return _read_yaml(section, quiet=quiet)
+
+
+def read_markdown(filename, mode='r'):
+    '''read the OTHER part of the markdown file (remove the frontend matter)
+    '''
+    stream = read_file(filename, mode, readlines=False)
+
+    # The yml section always comes after the --- of the frontmatter
+    return stream.split('---')[-1]
+
+
 # Json
 
 def write_json(json_obj, filename, mode="w", print_pretty=True):

--- a/schemaorg/version.py
+++ b/schemaorg/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'schemaorg'
@@ -31,4 +31,5 @@ LICENSE = "LICENSE"
 
 INSTALL_REQUIRES = (
    ('pyaml', {'min_version': '17.12.1'}),
+   ('lxml', {'min_version': '4.1.1' })
 )

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ if __name__ == "__main__":
           license=LICENSE,
           description=DESCRIPTION,
           long_description=LONG_DESCRIPTION,
+          long_description_content_type='text/markdown',
           keywords=KEYWORDS,
           install_requires = INSTALL_REQUIRES,
           classifiers=[


### PR DESCRIPTION
This pull request will simplify the RecipeParser client, adding many of the base classes to the RecipeBase. We do this so that the "special features" needed for a particular kind of recipe (e.g., schema recipe) are the only ones added, and not core functions like reading inputs/outputs. In addition, I'm adding a content type to the setup.py so that (possibly?) the markdown renders in pypi. There was also some redundancy in the function to do checks in the recipe parser (with the similar function to check if the file exists) so the first is removed.