### PR TITLE
recipeparser will be quiet when loading yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openschemas/schemaorg/tree/master)
+ - RecipeParser needs to honor verbosity level (and be quiet) (0.0.16)
  - added parser for json-ld embedded in html (0.0.15)
  - adding visual catalog template (0.0.14)
  - required/recommended should not be required for a recipe! [issue](https://github.com/openschemas/schemaorg/issues/6) (0.0.13)

--- a/schemaorg/main/parse/base.py
+++ b/schemaorg/main/parse/base.py
@@ -134,7 +134,7 @@ class RecipeBase(object):
 
             # Read in standard yaml
             else:
-                self.loaded = read_yaml(file_path)
+                self.loaded = read_yaml(file_path, quiet=True)
 
             # If the subclass has a load function, call now
             if hasattr(self, '_load'):

--- a/schemaorg/version.py
+++ b/schemaorg/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'schemaorg'


### PR DESCRIPTION
This PR will close #12 , specifically the RecipeParser needs to set quiet to True when loading the yaml to avoid unnecessary output.