### PR TITLE
Fix/contact type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openschemas/schemaorg/tree/master)
+ - ensuring that a Google Dataset contact_type is defined, and that empty lists / tuples are not added to Datasets (0.0.18)
  - Schema input should not check if the provided string exists, but is directory [issue](https://github.com/openschemas/schemaorg/issues/14) (0.0.17)
  - RecipeParser needs to honor verbosity level (and be quiet) (0.0.16)
  - added parser for json-ld embedded in html (0.0.15)

--- a/schemaorg/main/__init__.py
+++ b/schemaorg/main/__init__.py
@@ -115,7 +115,7 @@ class Schema(object):
             name: the name of the property, made to lowercase
             value: the value to add
         '''
-        if value not in ["", None]:
+        if value not in ["", None, [], ()]:
             if name in self._properties:
                 lookup = self._properties[name]
                 self.properties[name] = value

--- a/schemaorg/templates/google/__init__.py
+++ b/schemaorg/templates/google/__init__.py
@@ -27,7 +27,8 @@ from schemaorg.templates import get_template
 
 # Google Dataset Helpers
 
-def make_person(name, description, url="", telephone="", email=""):
+def make_person(name, description, url="", telephone="", email="", 
+                contact_type="customer support"):
 
     # Create an individual (persona)
     person = Schema('Person')
@@ -37,6 +38,7 @@ def make_person(name, description, url="", telephone="", email=""):
     # Update the contact point
     contactPoint.add_property('telephone', telephone)
     contactPoint.add_property('email', email)
+    contactPoint.add_property('contactType', contact_type)
 
     # Update the person with it
     person.add_property('contactPoint', contactPoint)

--- a/schemaorg/version.py
+++ b/schemaorg/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'schemaorg'


### PR DESCRIPTION
This pull request will add the "contact_type" as "customer support" to the function to create a person, along with ensuring that empty lists and tuples are not added as attributes when found empty :)