### PR TITLE
Fixing examples for spython updated recipe parser

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -146,8 +146,8 @@ Python [Dockerfile parser](https://singularityhub.github.io/singularity-cli/reci
 pip install spython
 ```
 ```python
-from spython.main.parse import DockerRecipe
-parser = DockerRecipe("Dockerfile")
+from spython.main.parse.parsers import DockerParser
+parser = DockerParser("Dockerfile").parse()
 ```
 Now here is how I add a property. Let's add the obvious ones from the Dockerfile.
 

--- a/examples/google/README.md
+++ b/examples/google/README.md
@@ -1,7 +1,7 @@
 # Schemaorg Example Parser
 
 This is an example of using schema.org to label a Dockerfile, and a Singularity Recipe.
-Specifically, we are following the Google Dataset guidelines, but pretending that they
+Note that updated examples are kept separately in [openbases/extract-dockerfile](https://www.github.com/openbases/extract-dockerfile). Specifically, we are following the Google Dataset guidelines, but pretending that they
 encompass a SoftwareSourceCode (e.g., a container recipe such as a Docker or Singularity
 recipe file). The example is shown in [extract_SoftwareSourceCode.py](extract_SoftwareSourceCode.py)
 and files included here are described in more detail below. Before running

--- a/examples/google/extract_ContainerRecipe.py
+++ b/examples/google/extract_ContainerRecipe.py
@@ -53,8 +53,8 @@ print(recipe.loaded)
 
 # Step 3: Extract Container Things! First, the recipe file
 
-from spython.main.parse import DockerRecipe
-parser = DockerRecipe("Dockerfile")
+from spython.main.parse.parsers import DockerParser
+parser = DockerParser('Dockerfile').parse()
 
 # containerRecipe.properties
 

--- a/examples/google/extract_SoftwareSourceCode.py
+++ b/examples/google/extract_SoftwareSourceCode.py
@@ -51,8 +51,8 @@ person = make_person(name="@vsoch",
 
 # Step 3: Create SoftwareSourceCode
 
-from spython.main.parse import DockerRecipe
-parser = DockerRecipe("Dockerfile")
+from spython.main.parse.parsers import DockerParser
+parser = DockerParser('Dockerfile').parse()
 
 sourceCode = Schema("SoftwareSourceCode")
 


### PR DESCRIPTION
This will update the examples for the current Singularity Python.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>