### PR TITLE
ensuring that lists of properties are correctly extracted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Critical items to know are:
 versions here coincide with releases on pypi.
 
 ## [master](https://github.com/openschemas/schemaorg/tree/master)
+ - bug with unwrapping lists of properties (0.0.24)
  - removing unneeded dependency of pwd, updating to 5.1 (0.0.23)
  - updating to latest version 5.0 (0.0.22)
  - Added download link to pages (0.0.21)

--- a/schemaorg/templates/metadata.py
+++ b/schemaorg/templates/metadata.py
@@ -46,8 +46,8 @@ def unwrap_properties(metadata):
             unwrapped[prop] = unwrap_properties(value.properties)
             unwrapped[prop].update({'@type': value.type})
         elif isinstance(value, list):
+            items = []
             for item in value:
-                items = []
                 if isinstance(item, Schema):
                     new_item = unwrap_properties(item.properties)
                     new_item.update({'@type': item.type})

--- a/schemaorg/version.py
+++ b/schemaorg/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.23"
+__version__ = "0.0.24"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'schemaorg'


### PR DESCRIPTION
This will fix a bug that lists of properties are not returned. The issue was the items list being one level too nested in the loop, hence the bug tag in #31. This will fix #31.

Signed-off-by: vsoch <vsochat@stanford.edu>